### PR TITLE
upgrade zlib to v1.2.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ endif()
 set(PROTOC "${CMAKE_CURRENT_BINARY_DIR}/protobuf/bin/protoc")
 
 # zlib
-set(ZLIB_VERSION 1.2.11)
+set(ZLIB_VERSION 1.2.12)
 set(ZLIB_URL https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz)
 
 ExternalProject_Add(zlib


### PR DESCRIPTION
Signed-off-by: Cwen Yin <cwenyin0@gmail.com> 

The  `https://zlib.net/zlib-1.2.11.tar.gz` link is dead. According to `https://zlib.net/` suggestion, we should use `1.2.12` replace `1.2.11`. 

![image](https://user-images.githubusercontent.com/22956341/160830937-b7a83644-ea79-4aa2-838d-2a24fef3badd.png)
