### PR TITLE
Bump zlib version from 1.2.12 to 1.2.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ endif()
 set(PROTOC "${CMAKE_CURRENT_BINARY_DIR}/protobuf/bin/protoc")
 
 # zlib
-set(ZLIB_VERSION 1.2.12)
+set(ZLIB_VERSION 1.2.13)
 set(ZLIB_URL https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz)
 
 ExternalProject_Add(zlib


### PR DESCRIPTION
extremely like https://github.com/chaos-mesh/bpfki/pull/1, bump zlib version.

close https://github.com/chaos-mesh/chaos-mesh/issues/3706